### PR TITLE
fix(package): update peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,21 @@
   "license": "ISC",
   "author": "Payfit Tech",
   "main": "index.js",
+  "files": [
+    "package.json",
+    "rules",
+    "index.js",
+    "node.js",
+    "react.js",
+    "jest.js"
+  ],
   "scripts": {
     "semantic-release": "semantic-release"
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "9.1.1",
@@ -49,20 +62,7 @@
     "eslint-plugin-react": "^7.16.0",
     "eslint-plugin-react-hooks": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "eslint-plugin-security": "^1.4.0",
-    "eslint-plugin-sonarjs": "^0.5.0",
+    "eslint-plugin-sonarjs": "^0.13.0",
     "eslint-plugin-xss": "^0.1.9"
-  },
-  "config": {
-    "commitizen": {
-      "path": "cz-conventional-changelog"
-    }
-  },
-  "files": [
-    "package.json",
-    "rules",
-    "index.js",
-    "node.js",
-    "react.js",
-    "jest.js"
-  ]
+  }
 }

--- a/rules/common/sonarjs.js
+++ b/rules/common/sonarjs.js
@@ -16,7 +16,7 @@ module.exports = {
     'sonarjs/max-switch-cases': 'warn',
     'sonarjs/no-duplicate-string': 'off',
     'sonarjs/no-duplicated-branches': 'warn',
-    'sonarjs/no-identical-functions': 'off',
+    'sonarjs/no-identical-functions': 'warn',
     'sonarjs/no-inverted-boolean-check': 'warn',
     'sonarjs/no-redundant-boolean': 'warn',
     'sonarjs/no-small-switch': 'warn',


### PR DESCRIPTION
- update "eslint-plugin-sonarjs" to accept newest versions of eslint as peerDependency (see accepted versions [here](https://github.com/SonarSource/eslint-plugin-sonarjs/blob/master/package.json#L33))
- re-enable (warn level for now) sonarjs `no-identical-functions` rule, which should not be off